### PR TITLE
Temporarily disable SSL verification to make Android work again

### DIFF
--- a/src/api/cprclient.cpp
+++ b/src/api/cprclient.cpp
@@ -12,7 +12,7 @@ CprClient::CprClient(std::string url, std::string name, std::string instanceId, 
 std::string CprClient::features() {
     auto response = cpr::Get(cpr::Url{m_url + "/client/features"}, cpr::Header{{"UNLEASH-INSTANCEID", m_instanceId},
                                                                                {"UNLEASH-APPNAME", m_name},
-                                                                               {"Authorization", m_authentication}});
+                                                                               {"Authorization", m_authentication}}, cpr::VerifySsl(0));
     if (response.status_code == 0) {
         std::cerr << response.error.message << std::endl;
         return std::string{};


### PR DESCRIPTION
Temporarily disable the SSL verification, which makes our Android app work again with the new, HTTPS enabled unleash instance.
A proper fix has been scheduled [here](https://app.clickup.com/t/86bx3954b)