### PR TITLE
Experimental/enable ssl verification again

### DIFF
--- a/include/unleash/api/cprclient.h
+++ b/include/unleash/api/cprclient.h
@@ -10,6 +10,7 @@ public:
     std::string features() override;
     bool registration(unsigned int refreshInterval) override;
 
+
 private:
     std::string m_url;
     std::string m_instanceId;

--- a/include/unleash/api/cprclient.h
+++ b/include/unleash/api/cprclient.h
@@ -11,6 +11,7 @@ public:
     std::string features() override;
     bool registration(unsigned int refreshInterval) override;
 
+    void setCABuffer(std::string caBuffer) { m_caBuffer = caBuffer; };
 
 private:
     std::string m_url;

--- a/include/unleash/api/cprclient.h
+++ b/include/unleash/api/cprclient.h
@@ -7,18 +7,16 @@ namespace unleash {
 class CprClient : public ApiClient {
 public:
     CprClient(std::string url, std::string name, std::string instanceId, std::string authentication = std::string(),
-              std::string caBuffer = std::string());
+              std::string caInfo = std::string());
     std::string features() override;
     bool registration(unsigned int refreshInterval) override;
-
-    void setCABuffer(std::string caBuffer) { m_caBuffer = caBuffer; };
 
 private:
     std::string m_url;
     std::string m_instanceId;
     std::string m_name;
     std::string m_authentication;
-    std::string m_caBuffer;
+    std::string m_caInfo;
 };
 }  // namespace unleash
 #endif  //UNLEASH_CPRCLIENT_H

--- a/include/unleash/api/cprclient.h
+++ b/include/unleash/api/cprclient.h
@@ -6,7 +6,8 @@
 namespace unleash {
 class CprClient : public ApiClient {
 public:
-    CprClient(std::string url, std::string name, std::string instanceId, std::string authentication = std::string());
+    CprClient(std::string url, std::string name, std::string instanceId, std::string authentication = std::string(),
+              std::string caBuffer = std::string());
     std::string features() override;
     bool registration(unsigned int refreshInterval) override;
 
@@ -16,6 +17,7 @@ private:
     std::string m_instanceId;
     std::string m_name;
     std::string m_authentication;
+    std::string m_caBuffer;
 };
 }  // namespace unleash
 #endif  //UNLEASH_CPRCLIENT_H

--- a/include/unleash/unleashclient.h
+++ b/include/unleash/unleashclient.h
@@ -44,7 +44,7 @@ private:
     std::string m_authentication;
     bool m_registration = false;
     std::string m_cacheFilePath;
-    std::string m_caBuffer;
+    std::string m_caInfo;
     unsigned int m_refreshInterval = 15000;
     std::thread m_thread;
     bool m_stopThread = false;
@@ -69,7 +69,7 @@ public:
     UnleashClientBuilder &authentication(std::string authentication);
     UnleashClientBuilder &registration(bool registration);
     UnleashClientBuilder &cacheFilePath(std::string cacheFilePath);
-    UnleashClientBuilder &caBuffer(std::string caBuffer);
+    UnleashClientBuilder &caInfo(std::string caInfo);
 
 private:
     UnleashClient unleashClient;

--- a/include/unleash/unleashclient.h
+++ b/include/unleash/unleashclient.h
@@ -44,6 +44,7 @@ private:
     std::string m_authentication;
     bool m_registration = false;
     std::string m_cacheFilePath;
+    std::string m_caBuffer;
     unsigned int m_refreshInterval = 15000;
     std::thread m_thread;
     bool m_stopThread = false;
@@ -68,6 +69,7 @@ public:
     UnleashClientBuilder &authentication(std::string authentication);
     UnleashClientBuilder &registration(bool registration);
     UnleashClientBuilder &cacheFilePath(std::string cacheFilePath);
+    UnleashClientBuilder &caBuffer(std::string caBuffer);
 
 private:
     UnleashClient unleashClient;

--- a/src/api/cprclient.cpp
+++ b/src/api/cprclient.cpp
@@ -6,12 +6,15 @@
 #include <nlohmann/json.hpp>
 
 namespace unleash {
-CprClient::CprClient(std::string url, std::string name, std::string instanceId, std::string authentication)
+CprClient::CprClient(std::string url, std::string name, std::string instanceId, std::string authentication,
+                     std::string caBuffer)
     : m_url(std::move(url)), m_instanceId(std::move(instanceId)), m_name(std::move(name)),
-      m_authentication(std::move(authentication)) {}
+      m_authentication(std::move(authentication)), m_caBuffer(std::move(caBuffer)) {}
 
 std::string CprClient::features() {
-    auto sslOptions = cpr::Ssl(cpr::ssl::CaInfo{"assets:/cacerts.pem"});
+    cpr::SslOptions sslOptions;
+
+    if (!m_caBuffer.empty()) { sslOptions.ca_buffer = m_caBuffer; }
     auto response = cpr::Get(cpr::Url{m_url + "/client/features"},
                              cpr::Header{{"UNLEASH-INSTANCEID", m_instanceId},
                                          {"UNLEASH-APPNAME", m_name},

--- a/src/api/cprclient.cpp
+++ b/src/api/cprclient.cpp
@@ -31,15 +31,18 @@ std::string CprClient::features() {
 }
 
 bool CprClient::registration(unsigned int refreshInterval) {
+    cpr::SslOptions sslOptions;
+
+    if (!m_caBuffer.empty()) { sslOptions.ca_buffer = m_caBuffer; }
     nlohmann::json payload;
     payload["appName"] = m_name;
     payload["interval"] = refreshInterval;
     payload["started"] = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
     payload["strategies"] = {"default", "userWithId", "flexibleRollout", "remoteAddress", "applicationHostname"};
 
-    if (auto response =
-                cpr::Post(cpr::Url{m_url + "/client/register"}, cpr::Body{payload.dump()},
-                          cpr::Header{{"Authorization", m_authentication}, {"Content-Type", "application/json"}});
+    if (auto response = cpr::Post(
+                cpr::Url{m_url + "/client/register"}, cpr::Body{payload.dump()},
+                cpr::Header{{"Authorization", m_authentication}, {"Content-Type", "application/json"}}, sslOptions);
         response.status_code == 0) {
         std::cerr << response.error.message << std::endl;
     } else if (response.status_code >= 400) {

--- a/src/api/cprclient.cpp
+++ b/src/api/cprclient.cpp
@@ -12,7 +12,7 @@ CprClient::CprClient(std::string url, std::string name, std::string instanceId, 
 std::string CprClient::features() {
     auto response = cpr::Get(cpr::Url{m_url + "/client/features"}, cpr::Header{{"UNLEASH-INSTANCEID", m_instanceId},
                                                                                {"UNLEASH-APPNAME", m_name},
-                                                                               {"Authorization", m_authentication}}, cpr::VerifySsl(0));
+                                                                               {"Authorization", m_authentication}});
     if (response.status_code == 0) {
         std::cerr << response.error.message << std::endl;
         return std::string{};

--- a/src/api/cprclient.cpp
+++ b/src/api/cprclient.cpp
@@ -1,6 +1,7 @@
 #include "unleash/api/cprclient.h"
 #include <chrono>
 #include <cpr/cpr.h>
+#include <cpr/ssl_options.h>
 #include <iostream>
 #include <nlohmann/json.hpp>
 
@@ -10,9 +11,12 @@ CprClient::CprClient(std::string url, std::string name, std::string instanceId, 
       m_authentication(std::move(authentication)) {}
 
 std::string CprClient::features() {
-    auto response = cpr::Get(cpr::Url{m_url + "/client/features"}, cpr::Header{{"UNLEASH-INSTANCEID", m_instanceId},
-                                                                               {"UNLEASH-APPNAME", m_name},
-                                                                               {"Authorization", m_authentication}});
+    auto sslOptions = cpr::Ssl(cpr::ssl::CaInfo{"assets:/cacerts.pem"});
+    auto response = cpr::Get(cpr::Url{m_url + "/client/features"},
+                             cpr::Header{{"UNLEASH-INSTANCEID", m_instanceId},
+                                         {"UNLEASH-APPNAME", m_name},
+                                         {"Authorization", m_authentication}},
+                             sslOptions);
     if (response.status_code == 0) {
         std::cerr << response.error.message << std::endl;
         return std::string{};

--- a/src/unleashclient.cpp
+++ b/src/unleashclient.cpp
@@ -52,8 +52,8 @@ UnleashClientBuilder &UnleashClientBuilder::cacheFilePath(std::string cacheFileP
     return *this;
 }
 
-UnleashClientBuilder &UnleashClientBuilder::caBuffer(std::string caBuffer) {
-    unleashClient.m_caBuffer = std::move(caBuffer);
+UnleashClientBuilder &UnleashClientBuilder::caInfo(std::string caInfo) {
+    unleashClient.m_caInfo = std::move(caInfo);
     return *this;
 }
 
@@ -61,7 +61,7 @@ void UnleashClient::initializeClient() {
     if (!m_isInitialized) {
         // Set-up Unleash API client
         if (m_apiClient == nullptr) {
-            m_apiClient = std::make_unique<CprClient>(m_url, m_name, m_instanceId, m_authentication, m_caBuffer);
+            m_apiClient = std::make_unique<CprClient>(m_url, m_name, m_instanceId, m_authentication, m_caInfo);
         }
 
         // Register the Client

--- a/src/unleashclient.cpp
+++ b/src/unleashclient.cpp
@@ -52,11 +52,16 @@ UnleashClientBuilder &UnleashClientBuilder::cacheFilePath(std::string cacheFileP
     return *this;
 }
 
+UnleashClientBuilder &UnleashClientBuilder::caBuffer(std::string caBuffer) {
+    unleashClient.m_caBuffer = std::move(caBuffer);
+    return *this;
+}
+
 void UnleashClient::initializeClient() {
     if (!m_isInitialized) {
         // Set-up Unleash API client
         if (m_apiClient == nullptr) {
-            m_apiClient = std::make_unique<CprClient>(m_url, m_name, m_instanceId, m_authentication);
+            m_apiClient = std::make_unique<CprClient>(m_url, m_name, m_instanceId, m_authentication, m_caBuffer);
         }
 
         // Register the Client


### PR DESCRIPTION
Add the ability to pass a filename containing a CA bundle to the underlying cpr for all GET and POST calls. This is done because on android the native CA files are not found if unleash & cpr are compiled against openSSL 1.1.x instead of openSSL 3.x

The cacert.pem file to be passed can be downloaded here: https://curl.se/docs/caextract.html

We should push these changes upstream once we are Ok with it. 