### PR TITLE
Fix empty values[] case

### DIFF
--- a/src/strategies/strategy.cpp
+++ b/src/strategies/strategy.cpp
@@ -21,7 +21,7 @@ Strategy::Strategy(std::string name, std::string_view constraints) : m_name(std:
         for (const auto &[key, value] : constraint_json.items()) {
             if ((value.contains("contextName") && value.contains("operator"))) {
                 Constraint strategyConstraint{value["contextName"], value["operator"]};
-                if (value.contains("values")){
+                if (value.contains("values") && value["values"].size() > 0){
                     for (const auto &[valuesKey, valuesValue] : value["values"].items()) {
                         strategyConstraint.values.push_back(valuesValue);
                     }


### PR DESCRIPTION
Fixes a bug where, for constraints that only specify `value` instead of an array of `values[]`, the value would not get read, causing evaluation to segfault when trying to manipulate the first element of an empty array.

Example:

"constraints": [
    {
      "value": "9998",
      "values": [],
      "inverted": false,
      "operator": "NUM_LT",
      "contextName": "vehicleId",
      "caseInsensitive": false
    }
  ],

would be parsed to a constraints that has still `values = []` instead of `values = [9998]`, because the API response has a "values" object in the json, although it's an empty array.